### PR TITLE
ucs: do not report error if hugepage shmget fails

### DIFF
--- a/config/m4/sysdep.m4
+++ b/config/m4/sysdep.m4
@@ -131,3 +131,14 @@ CHECK_CROSS_COMP([AC_LANG_SOURCE([#include <malloc.h>
                   AC_MSG_WARN([malloc hooks are not supported])]
                 )
 CFLAGS=$SAVE_CFLAGS
+
+
+#
+# Check for capability.h header (usually comes from libcap-devel package) and
+# make sure it defines the types we need
+#
+AC_CHECK_HEADERS([sys/capability.h],
+                 [AC_CHECK_TYPES([cap_user_header_t, cap_user_data_t], [],
+                                 [AC_DEFINE([HAVE_SYS_CAPABILITY_H], [0], [Linux capability API support])],
+                                 [[#include <sys/capability.h>]])]
+                 )


### PR DESCRIPTION
## What
Do not report UCX error when hugepage shmget fails

## Why ?
`uct_mm_mem_alloc` always tries to allocate hugepage first,
and falls back to regular allocation if hugepage fails. However, ucs
reports a hugepage allocation failure as error (e.g., `shmget` returns
`EPERM` on `CAP_IPC_LOCK`-disabled platform), which is not suitable.

## How ?
Cherry-picked a recent commit from ucx/master